### PR TITLE
Updated ConfigMgrCleanHealth and CreateDatabase.

### DIFF
--- a/CreateDatabase.sql
+++ b/CreateDatabase.sql
@@ -57,6 +57,7 @@ CREATE TABLE dbo.Clients
     StateMessages varchar(50),
     WUAHandler varchar(50),
     WMI varchar(50),
+    RefreshComplianceState smalldatetime,
     ClientInstalled smalldatetime,
     Version varchar(10),
     Timestamp datetime,
@@ -75,6 +76,7 @@ IF NOT EXISTS (SELECT * FROM sys.columns WHERE  object_id = OBJECT_ID(N'[dbo].[C
 IF NOT EXISTS (SELECT * FROM sys.columns WHERE  object_id = OBJECT_ID(N'[dbo].[Clients]') AND name = 'BITS') ALTER TABLE dbo.Clients ADD BITS varchar(50)
 IF NOT EXISTS (SELECT * FROM sys.columns WHERE  object_id = OBJECT_ID(N'[dbo].[Clients]') AND name = 'PatchLevel') ALTER TABLE dbo.Clients ADD PatchLevel int
 IF NOT EXISTS (SELECT * FROM sys.columns WHERE  object_id = OBJECT_ID(N'[dbo].[Clients]') AND name = 'ClientInstalledReason') ALTER TABLE dbo.Clients ADD ClientInstalledReason varchar(200)
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE  object_id = OBJECT_ID(N'[dbo].[Clients]') AND name = 'RefreshComplianceState') ALTER TABLE dbo.Clients ADD RefreshComplianceState smalldatetime
 
 
 -- Modify columns if needed

--- a/config.xml
+++ b/config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+	<LocalFiles>$($env:ProgramData)\ConfigMgrClientHealth</LocalFiles> <!-- Path locally on computer for temporary files and local clienthealth.log if LocalLogFile="True" -->
+	<Client Name="Version">5.00.8498.1711</Client>
+	<Client Name="SiteCode">IUS</Client>
+	<Client Name="Domain">ius.meijer.com</Client>
+	<Client Name="AutoUpgrade">True</Client>
+	<Client Name="Share"></Client>
+	<Client Name="CacheSize" Value="10240" DeleteOrphanedData="True" Enable="True" />
+	<Client Name="Log" MaxLogSize="4096" MaxLogHistory="1" Enable="True" />
+	<ClientInstallProperty>SMSSITECODE=IUS</ClientInstallProperty>
+	<ClientInstallProperty>DNSSUFFIX=ius.meijer.com</ClientInstallProperty>
+	<ClientInstallProperty>CCMLOGMAXSIZE=2621440</ClientInstallProperty>
+	<ClientInstallProperty>/skipprereq:silverlight.exe</ClientInstallProperty>
+	<ClientInstallProperty>/MP:w0982iappv0601.ius.meijer.com</ClientInstallProperty>
+	<Log Name="File" Share="$($env:ProgramData)\ConfigMgrClientHealth\Logs" Level="Full" MaxLogHistory="8" LocalLogFile="True" Enable="False" /> <!-- Level: Full = everything. ClientInstall = only if installation of sccm agent fails.  -->
+	<Log Name="SQL" Server="CM01.rodland.lab" Enable="False" />
+	<Log Name="Time" Format="ClientLocal" /> <!-- Valid formats: ClientLocal / UTC  -->
+	<Option Name="CcmSQLCELog" Enable="False" /> <!-- Optional check on the ConfigMgr agent if local database is corrupt -->
+	<Option Name="BITSCheck" Fix="True" Enable="True" />
+	<Option Name="DNSCheck" Fix="True" Enable="True" />
+	<Option Name="Drivers" Enable="True" />
+	<Option Name="Updates" Share="" Fix="True" Enable="True" />
+	<Option Name="PendingReboot" StartRebootApplication="True"  Enable="False" />
+	<Option Name="RebootApplication" Application="\\CM01.rodland.lab\ClientHealth$\RebootApp\shutdowntool.exe /t:7200 /m:1440" Enable="False" />
+	<Option Name="MaxRebootDays" Days="7" Enable="False" />
+	<Option Name="OSDiskFreeSpace">10</Option>
+	<Option Name="HardwareInventory" Days="10" Fix="True" Enable="True" />
+	<Option Name="SoftwareMetering" Fix="True" Enable="True" />
+	<Option Name="WMI" Fix="True" Enable="True"/>
+	<Option Name="RefreshComplianceState" Days="30" Enable="True"/>
+	<Service Name="BITS" StartupType="Automatic (Delayed Start)" State="Running" Uptime="" />
+	<Service Name="winmgmt" StartupType="Automatic" State="Running" Uptime="" />
+	<Service Name="wuauserv" StartupType="Automatic (Delayed Start)" State="Running" Uptime="" />
+	<Service Name="lanmanserver" StartupType="Automatic" State="Running" Uptime="" />
+	<Service Name="RpcSs" StartupType="Automatic" State="Running" Uptime="" />
+	<Service Name="W32Time" StartupType="Automatic" State="Running" Uptime="" />
+	<Service Name="ccmexec" StartupType="Automatic (Delayed Start)" State="Running" Uptime="7" />
+	<Remediation Name="AdminShare" Fix="True" />
+	<Remediation Name="ClientProvisioningMode" Fix="True" />
+	<Remediation Name="ClientStateMessages" Fix="True" />
+	<Remediation Name="ClientWUAHandler" Fix="True" Days="" />
+	<Remediation Name="ClientCertificate" Fix="True" />
+</Configuration>


### PR DESCRIPTION
-Modified the Config parameter to accept null.  When no config file is provided it defaults to the Config.xml file in the script's directory.  This allows the script to ran without parameters making manually runnig it easier.
-Modified Get-XMLConfigUpdatesShare and Get-XMLConfigClientShare to default to the Updates folder in the script's directory if no Share value is provided.  This makes the script more portable.
-Modified   to default to the Updates folder in the script's directory if no Share value is provided.  This makes the script more portable.
-Modified Resolve-Client  to call Get-XMLConfigClientShare (the function was there but unused).
-Added function Search-CMLogFile to loop bacwards through a log file up to the start time looking for a matching entry.  Used to limit log searched to the last time the script ran.
-Added function Set-RegistryValue to set a registry value including creating the key when necessary.
-Modified function Get-RegistryValue (unused in 0.7.4) to fail silently and return nothing if the registry value does not exist.
-Modified function Resolve-Client to accept an empty client share element and default to the script directory.  This allows to user to put ccmexec in the root of the script directory making the script more portable.
-Read and write a timestamp stored in the registry that indicates the last time the script ran.  This is used to filter certain searches (ex. Search-CMLogFile)

-Modified Get-LocalFilesPath:
    -Expand the string to support using environment variables in the config file.
    -Use environment variable when setting default.

-Added a Service element for ccmexec in the configuration file to allow for its service remediation features to be configured.
    -Added it last in the config file because it triggers msiexec that causes other services have to wait before they can restart.  
    -Removed the lines that handle that service separately.

-Modified Test-RegistryPol:
    -Add Days parameter to manage the maximum age of the machine policy file. Leave blank to never delete the file based on age.
    -Add StartTime parameter to limit how far back we search the log and event viewer.
    -Use environment variables for Windows directory instead of hardcoding.
    -Add force parameter for GPUpdate to force it to process all policy instead of just a delta.
    -Centralize the remediation steps using RepairReason variable.
    -Added event viewer check for documented event IDs that indicate group policy processing errors.
    -Use the Search-CMLogFile function to limit how far back we search WUAUHander for errors.  This eliminates the need to delete the log.

-Modified Test-Service:
    -Added Uptime parameter that will restart the service if it has been running for longer then the configured number of days.
        -Added a parameter called Uptime to the configuration file's Service element.
        -The script will wait up to 30 minutes for certain installation processes to stop.  This hopefully prevents creating issues with restarting the services.
        
-Added Test-RefreshComplianceState
    -Will resend the client's compliance states.  The Test-UpdateStore function already does this if a state message problem is found but there are situations where the client is fine but the messages are still missed.
    -To spread out the load the client will randomly resend the states between the current date and the next scheduled date to resend.
    -Write the last sent date to the registry to determine when the next scheduled date is based on the number of days configured.
    -Added RefreshComplianceState configuration element to the config file.
    -Added RefreshComplianceState field to the log object and SQL database and modified the logging function to write the last time the compliance state was refreshed.

-Modified Test-Update:
    -Moved the Get-XMLConfigUpdatesEnable check into the main routine for consistency and cleaner logging.
    -Add warning if the updates folder can not be found.
    -Used Join-Path rather than string concatination.  Some of the folders were not computing correctly.