### PR TITLE
Update ConfigMgrClientHealth.ps1

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -1036,7 +1036,8 @@ Begin {
                 'fixed' {$text = "ConfigMgr Client Cache Size: $CurrentCache. Expected: $ClientCacheSize. Redmediating."}
                 'percentage' {
                     $percent = Get-XMLConfigClientCache
-                    $text = "ConfigMgr Client Cache Size: $CurrentCache. Expected: $ClientCacheSize ($percent). Redmediating."
+                    if ($ClientCacheSize -gt "99999") { $ClientCacheSize = "99999" }
+                    $text = "ConfigMgr Client Cache Size: $CurrentCache. Expected: $ClientCacheSize ($percent). (99999 maxium). Redmediating."
                 }
             }
             


### PR DESCRIPTION
If a percentage value for the client cache size is set, the maxium client cache value is 99999. Anything over it will result in an error.