### PR TITLE
Update Get-LastInstalledPatches for accuracy

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -682,12 +682,36 @@ Begin {
         
         $OS = Get-OperatingSystem
         Switch -Wildcard ($OS) {
-            "*Windows 7*" { $Date = $Searcher.QueryHistory(0,$HistoryCount) | Where-Object {$_.ClientApplicationID -eq 'AutomaticUpdates'} | Select-Object -ExpandProperty Date | Measure-Latest }
-            "*Windows 8*" { $Date = $Searcher.QueryHistory(0,$HistoryCount) | Where-Object {$_.ClientApplicationID -eq 'AutomaticUpdatesWuApp'} | Select-Object -ExpandProperty Date | Measure-Latest }
-            "*Windows 10*" { $Date = $Searcher.QueryHistory(0,$HistoryCount) | Where-Object {$_.ClientApplicationID -eq 'UpdateOrchestrator'} | Select-Object -ExpandProperty Date | Measure-Latest }
-            "*Server 2008*" { $Date = $Searcher.QueryHistory(0,$HistoryCount) | Where-Object {$_.ClientApplicationID -eq 'AutomaticUpdates'} | Select-Object -ExpandProperty Date | Measure-Latest }
-            "*Server 2012*" { $Date = $Searcher.QueryHistory(0,$HistoryCount) | Where-Object {$_.ClientApplicationID -eq 'AutomaticUpdatesWuApp'} | Select-Object -ExpandProperty Date | Measure-Latest }
-            "*Server 2016*" { $Date = $Searcher.QueryHistory(0,$HistoryCount) | Where-Object {$_.ClientApplicationID -eq 'UpdateOrchestrator'} | Select-Object -ExpandProperty Date | Measure-Latest }
+            "*Windows 7*" {
+                $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
+                    ($_.ClientApplicationID -eq 'AutomaticUpdates' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                } | Select-Object -ExpandProperty Date | Measure-Latest
+            }
+            "*Windows 8*" {
+                $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
+                    ($_.ClientApplicationID -eq 'AutomaticUpdatesWuApp' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                } | Select-Object -ExpandProperty Date | Measure-Latest
+            }
+            "*Windows 10*" {
+                $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
+                    ($_.ClientApplicationID -eq 'UpdateOrchestrator' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                } | Select-Object -ExpandProperty Date | Measure-Latest
+            }
+            "*Server 2008*" {
+                $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
+                    ($_.ClientApplicationID -eq 'AutomaticUpdates' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                } | Select-Object -ExpandProperty Date | Measure-Latest
+            }
+            "*Server 2012*" {
+                $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
+                    ($_.ClientApplicationID -eq 'AutomaticUpdatesWuApp' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                } | Select-Object -ExpandProperty Date | Measure-Latest
+            }
+            "*Server 2016*" {
+                $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
+                    ($_.ClientApplicationID -eq 'UpdateOrchestrator' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                } | Select-Object -ExpandProperty Date | Measure-Latest
+            }
         }
 
         # Reading date from PowerShell Get-Hotfix


### PR DESCRIPTION
Function now filters out 'Definition Updates' and also checks for patches installed from the 'ccmexec' applicationID.

The function now provides a more accurate representation of 'last patch' date. We noticed that the 'ClientApplicationID' comes down as ccmexec in many cases when updates are applied via SCCM. In our environment we also choose to not have a 'Definition Update' trigger the 'lastinstalledpatches' date. 

Attached is the result of three outputs on a Windows 10 1803 system that is patched via SCCM.

You'll see that the function as provided from the ClientHealth script (ran last) provides no output, while the other two provides [datetime] objects. 

![image](https://user-images.githubusercontent.com/28543620/49020161-c68a3900-f15d-11e8-8489-b8af21e5b26a.png)
