### PR TITLE
Test and repair root/ccm WMI

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -1138,9 +1138,13 @@ Begin {
                 if ($PowerShellVersion -ge 6) { $WMI = Get-CimInstance -Namespace root/ccm -Class SMS_Client -ErrorAction Stop }
                 else { $WMI = Get-WmiObject -Namespace root/ccm -Class SMS_Client -ErrorAction Stop }
             } Catch {
-                Write-Verbose 'Failed to connect to WMI namespace "root/ccm" class "SMS_Client". Tagging client for reinstall to fix.'
+                Write-Verbose 'Failed to connect to WMI namespace "root/ccm" class "SMS_Client". Clearing WMI and tagging client for reinstall to fix.'
+
+                # Clear the WMI namespace to avoid having to uninstall first
+                # This is the same action the install after an uninstall would perform
+                Get-WmiObject -Query "Select * from __Namespace WHERE Name='CCM'" -Namespace root | Remove-WmiObject
+
                 $Reinstall = $true
-                $Uninstall = $true
                 New-ClientInstalledReason -Log $Log -Message "Failed to connect to SMS_Client WMI class."
             }
 

--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -1133,6 +1133,17 @@ Begin {
                 }
             }
 
+            # Test that we are able to connect to SMS_Client WMI class
+            Try {
+                if ($PowerShellVersion -ge 6) { $WMI = Get-CimInstance -Namespace root/ccm -Class SMS_Client -ErrorAction Stop }
+                else { $WMI = Get-WmiObject -Namespace root/ccm -Class SMS_Client -ErrorAction Stop }
+            } Catch {
+                Write-Verbose 'Failed to connect to WMI namespace "root/ccm" class "SMS_Client". Tagging client for reinstall to fix.'
+                $Reinstall = $true
+                $Uninstall = $true
+                New-ClientInstalledReason -Log $Log -Message "Failed to connect to SMS_Client WMI class."
+            }
+
             if ( $reinstall -eq $true) {
                 $text = "ConfigMgr Client Health thinks the agent need to be reinstalled.."
                 Write-Host $text
@@ -1609,14 +1620,6 @@ Begin {
         } Catch {
             Write-Verbose 'Failed to connect to WMI class "Win32_ComputerSystem". Voting for WMI fix...'
             $vote++
-        }
-
-        Try {
-            if ($PowerShellVersion -ge 6) { $WMI = Get-CimInstance -Namespace root/ccm -Class SMS_Client -ErrorAction Stop }
-            else { $WMI = Get-WmiObject -Namespace root/ccm -Class SMS_Client -ErrorAction Stop }
-        } Catch {
-            Write-Verbose 'Failed to connect to WMI namespace "root/ccm" class "SMS_Client". Tagging client for reinstall instead of WMI fix.'
-            $obj = $true
         } Finally {
             if ($vote -eq 0) {
                 $text = 'WMI Check: OK'

--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -1590,6 +1590,7 @@ Begin {
     Function Test-WMI {
         Param([Parameter(Mandatory=$true)]$Log)
         $vote = 0
+        $obj = $false
 
         $result = winmgmt /verifyrepository
         switch -wildcard ($result) {
@@ -1621,7 +1622,6 @@ Begin {
                 $text = 'WMI Check: OK'
                 $log.WMI = 'OK'
                 Write-Host $text
-                $obj = $false
             }
             else {
                 $fix = Get-XMLConfigWMIRepairEnable
@@ -3703,11 +3703,11 @@ Process {
 		Write-Verbose 'Validating Windows Update Scan not broken by bad group policy...'
         $days = Get-XMLConfigRemediationClientWUAHandlerDays
         Test-RegistryPol -Days $days -log $log -StartTime $LastRun
-        
+
     }
 
-    
-    if (($ClientStateMessages -like 'True') -eq $true) { 
+
+    if (($ClientStateMessages -like 'True') -eq $true) {
         Write-Verbose 'Validating that CCMClient is sending state messages...'
         Test-UpdateStore -log $log
     }


### PR DESCRIPTION
Fix being unable to connect to WMI namespace `root/ccm` class `SMS_Client`, which is currently being tested for but not repaired in Test-WMI. This issue can manifest as `ccmsetup` failing to install the client (error code 0x80041013, if memory serves), or a Provider Load Failure when attempting to connect via `get-wmiobject` and similar.

The fix requires either:

-	uninstalling and reinstalling the client. The actual fixing is performed during the install, ccmsetup logs "Namespace root\ccm exists but SCCM client or MP/MCS/PullDP is not installed. Clear the namespace in case it's not cleaned up properly by the last client uninstallation."
-	clearing the namespace and reinstalling the client, which I went for.

The testing of the namespace is also moved from `Test-WMI` to `Test-ConfigMgrClient`, as it seemed more relevant there.