### PR TITLE
Use $PSBoundParameters.ContainsKey for webservice checks

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -3813,12 +3813,12 @@ End {
         Update-LogFile -Log $log
     }
 
-    if (($SQLLogging -like 'true') -and (($Webservice -eq $null) -or ($Webservice -eq ""))) {
+    if (($SQLLogging -eq 'true') -and -not $PSBoundParameters.ContainsKey('Webservice')) {
         Write-Output 'Updating SQL database with results'
         Update-SQL -Log $log
     }
 
-    if ($Webservice) {
+    if ($PSBoundParameters.ContainsKey('Webservice')) {
         Write-Output 'Updating SQL database with results using webservice'
         Update-Webservice -URI $Webservice -Log $Log
     }


### PR DESCRIPTION
SQLLogging was getting triggered even when it was false in the config. These edits seem to resolve the issue.

We check for the 'WebService' parameter being specified instead of checking for it being $null or ""