### PR TITLE
Fix using default config

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -56,7 +56,10 @@ Begin {
     $global:ScriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
     #If no config file was passed in, use the default.
-    If ((!$Config) -and ($Webservice -eq $null)) {$Config = Join-Path ($global:ScriptPath) "Config.xml"}
+    If ((!$PSBoundParameters.ContainsKey('Config')) -and (!$PSBoundParameters.ContainsKey('Webservice'))) {
+        $Config = Join-Path ($global:ScriptPath) "Config.xml"
+        Write-Verbose "No config provided, defaulting to $Config"
+    }
 
     Write-Verbose "Script version: $Version"
     Write-Verbose "PowerShell version: $PowerShellVersion"


### PR DESCRIPTION
Previously if neither `-config` nor `-webservice` was provided, script would execute with `$Config` set to `''`. Resolve this and use `PSBoundParameters` to check params.