### PR TITLE
Write log in ConfigMgr format

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -339,7 +339,14 @@ Begin {
     }
 
     Function Out-LogFile {
-        Param([Parameter(Mandatory=$false)][xml]$Xml, $Text, $Mode)
+        Param([Parameter(Mandatory = $false)][xml]$Xml, $Text, $Mode,
+            [Parameter(Mandatory = $false)][ValidateSet(1, 2, 3, 'Information', 'Warning', 'Error')]$Severity = 1)
+
+        switch ($Severity) {
+            'Information' {$Severity = 1}
+            'Warning' {$Severity = 2}
+            'Error' {$Severity = 3}
+        }
 
         if ($Mode -like "Local") {
             Test-LocalLogging
@@ -356,7 +363,7 @@ Begin {
             $date = 'date="' + (Get-Date -Format MM-dd-yyyy) + '"'
             $component = 'component="ConfigMgrClientHealth"'
             $context = 'context=""'
-            $type = 'type="1"'  #Severity 1=Information, 2=Warning, 3=Error
+            $type = 'type="' + $Severity + '"'  #Severity 1=Information, 2=Warning, 3=Error
             $thread = 'thread="' + $PID + '"'
             $file = 'file=""'
 

--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -350,8 +350,22 @@ Begin {
 
         if ($mode -like "ClientInstall" ) { $text = "ConfigMgr Client installation failed. Agent not detected 10 minutes after triggering installation." }
 
-        $obj = '[' +(Get-DateTime) +'] '+$text
-        $obj | Out-File -Encoding utf8 -Append $logFile
+        foreach ($item in $text) {
+            $item = '<![LOG[' + $item + ']LOG]!>'
+            $time = 'time="' + (Get-Date -Format HH:mm:ss.fff) + '+000"' #Should actually be the bias
+            $date = 'date="' + (Get-Date -Format MM-dd-yyyy) + '"'
+            $component = 'component="ConfigMgrClientHealth"'
+            $context = 'context=""'
+            $type = 'type="1"'  #Severity 1=Information, 2=Warning, 3=Error
+            $thread = 'thread="' + $PID + '"'
+            $file = 'file=""'
+
+            $logblock = ($time, $date, $component, $context, $type, $thread, $file) -join ' '
+            $logblock = '<' + $logblock + '>'
+
+            $item + $logblock | Out-File -Encoding utf8 -Append $logFile
+        }
+        # $obj | Out-File -Encoding utf8 -Append $logFile
     }
 
     Function Get-OperatingSystem {


### PR DESCRIPTION
Write the log files in the format cm uses for logs so that they're easier to read in cmtrace/etc. Includes adding severity flags for existing log messages.