### PR TITLE
Choose desired client version based on ccmsetup

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -1615,7 +1615,7 @@ Begin {
                 Start-Sleep -Seconds 360
             }
 
-            
+
 
         }
         else {
@@ -2523,6 +2523,10 @@ Begin {
     Function Get-XMLConfigClientVersion {
         if ($config) {
             $obj = $Xml.Configuration.Client | Where-Object {$_.Name -like 'Version'} | Select-Object -ExpandProperty '#text'
+            if ($obj.ToLower() -eq 'auto') {
+                $ClientShare = Get-XMLConfigClientShare
+                $obj = (Get-Item (Join-Path $ClientShare 'ccmsetup.exe')).VersionInfo.ProductVersion
+            }
         }
 
         Write-Output $obj


### PR DESCRIPTION
Enable using the ccmsetup.exe that would be used to install the client
as the desired client version for upgrading, rather than manually
specifying by setting the desired client version to 'auto'.

This would mean the only file that needs changing when a new configmgr version is used is the actual installer, instead of having to update the config file with a new version too.