### PR TITLE
Update criteria for excluding Defender signature updates

### DIFF
--- a/ConfigMgrClientHealth.ps1
+++ b/ConfigMgrClientHealth.ps1
@@ -844,32 +844,32 @@ Begin {
         Switch -Wildcard ($OS) {
             "*Windows 7*" {
                 $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
-                    ($_.ClientApplicationID -eq 'AutomaticUpdates' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                    ($_.ClientApplicationID -eq 'AutomaticUpdates' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Security Intelligence Update|Definition Update")
                 } | Select-Object -ExpandProperty Date | Measure-Latest
             }
             "*Windows 8*" {
                 $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
-                    ($_.ClientApplicationID -eq 'AutomaticUpdatesWuApp' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                    ($_.ClientApplicationID -eq 'AutomaticUpdatesWuApp' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Security Intelligence Update|Definition Update")
                 } | Select-Object -ExpandProperty Date | Measure-Latest
             }
             "*Windows 10*" {
                 $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
-                    ($_.ClientApplicationID -eq 'UpdateOrchestrator' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                    ($_.ClientApplicationID -eq 'UpdateOrchestrator' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Security Intelligence Update|Definition Update")
                 } | Select-Object -ExpandProperty Date | Measure-Latest
             }
             "*Server 2008*" {
                 $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
-                    ($_.ClientApplicationID -eq 'AutomaticUpdates' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                    ($_.ClientApplicationID -eq 'AutomaticUpdates' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Security Intelligence Update|Definition Update")
                 } | Select-Object -ExpandProperty Date | Measure-Latest
             }
             "*Server 2012*" {
                 $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
-                    ($_.ClientApplicationID -eq 'AutomaticUpdatesWuApp' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                    ($_.ClientApplicationID -eq 'AutomaticUpdatesWuApp' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Security Intelligence Update|Definition Update")
                 } | Select-Object -ExpandProperty Date | Measure-Latest
             }
             "*Server 2016*" {
                 $Date = $Searcher.QueryHistory(0, $HistoryCount) | Where-Object {
-                    ($_.ClientApplicationID -eq 'UpdateOrchestrator' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Definition Update")
+                    ($_.ClientApplicationID -eq 'UpdateOrchestrator' -or $_.ClientApplicationID -eq 'ccmexec') -and ($_.Title -notmatch "Security Intelligence Update|Definition Update")
                 } | Select-Object -ExpandProperty Date | Measure-Latest
             }
 		}


### PR DESCRIPTION
The search criteria used to exclude Defender signature updates from the update date check is using an old name. Microsoft changed the title to replace "Definition Update" with "Security Intelligence Update" in 2019. As a result, the script is not excluding these updates and the date shown doesn't reflect the last non-Defender update.

This fix matches on both terms to cover the situation where an older system with the old term is being checked.
